### PR TITLE
Client does not create a valid signature when spaces are in the URL.

### DIFF
--- a/CloudStack/BaseClient.py
+++ b/CloudStack/BaseClient.py
@@ -22,7 +22,7 @@ class BaseClient(object):
         keys = sorted(args.keys())
 
         for k in keys:
-            params.append(k + '=' + urllib.quote_plus(args[k])) 
+            params.append(k + '=' + urllib.quote_plus(args[k]).replace("+", "%20"))
        
         query = '&'.join(params)
 


### PR DESCRIPTION
I noticed while trying to register an ssh key with registerSSHKeyPair that the client was generating an invalid signature when a space was added in the parameters. The API is expecting spaces to be encoded with %20, not +. This commit replaces the encoded +'s with %20.
